### PR TITLE
add support for dependency tree rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "archy": "^1.0.0",
     "bower": "^1.3.12",
     "bower-config": "^0.5.2",
+    "chalk": "^0.5.1",
     "inquirer": "^0.8.0",
     "mout": "^0.11.0"
   },


### PR DESCRIPTION
adds support for printing the dependency tree of a package, by directly using the function and package([archy](https://github.com/substack/node-archy)), that bower itself uses.

current output
```
Running "bower:list" (bower) task
check-new >> Checking for new versions of the project dependencies..
>> dependency tree:
bower-demo#1.0.0
├── JSON-js#3d7767b6b1
└── jquery#1.7.2 incompatible with ~2.1.3 (2.1.3 available)

>> Bower command finished.

Done, without errors.
```